### PR TITLE
fix: four-language client/server tweaks (dart, python, rust, ts)

### DIFF
--- a/hello-websocket-dart/client/ws_client.dart
+++ b/hello-websocket-dart/client/ws_client.dart
@@ -43,7 +43,7 @@ Future<void> _tryConnect(String url) async {
   var randomId = 1;
   Timer.periodic(Duration(milliseconds: randomIntervalMs), (t) {
     if (ws.readyState != WebSocket.open) { t.cancel(); return; }
-    final num = rng.nextInt(9007199254740991);
+    final num = (rng.nextInt(1 << 31) << 32) | rng.nextInt(1 << 32);
     ws.add(randomNumberMsg(randomId, num).encode());
     log('ws-client', 'RANDOM_NUMBER id=$randomId number=$num');
     randomId++;

--- a/hello-websocket-python/client/ws_client.py
+++ b/hello-websocket-python/client/ws_client.py
@@ -59,7 +59,7 @@ async def run_client(host: str, port: int):
                     log("ws-client", f"PING ts={msg.ping.timestamp_ms}")
                     pong = Pong(timestamp_ms=msg.ping.timestamp_ms)
                     await ws.send(pong.encode())
-                    log("ws-client", f"PONG ts={msg.pong.timestamp_ms}")
+                    log("ws-client", f"PONG ts={pong.timestamp_ms}")
 
                 elif msg.type == MSG_TIME_NOTIFICATION:
                     log("ws-client", f"TIME_NOTIFICATION ts={msg.time_notif.timestamp_ms} iso={msg.time_notif.iso8601}")

--- a/hello-websocket-rust/Cargo.lock
+++ b/hello-websocket-rust/Cargo.lock
@@ -18,16 +18,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -42,10 +45,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -61,6 +90,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -72,8 +110,19 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -129,13 +178,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.17"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "r-efi 5.3.0",
+ "wasip2",
 ]
 
 [[package]]
@@ -146,7 +196,8 @@ checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -154,7 +205,7 @@ name = "hello_websocket"
 version = "0.1.0"
 dependencies = [
  "futures-util",
- "rand",
+ "rand 0.10.2",
  "sha2",
  "tokio",
  "tokio-tungstenite",
@@ -176,6 +227,15 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "itoa"
@@ -290,39 +350,61 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
- "getrandom 0.2.17",
+ "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "redox_syscall"
@@ -352,19 +434,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -412,18 +494,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.69"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -460,9 +542,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.24.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
 dependencies = [
  "futures-util",
  "log",
@@ -472,20 +554,18 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.24.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
- "byteorder",
  "bytes",
  "data-encoding",
  "http",
  "httparse",
  "log",
- "rand",
+ "rand 0.9.4",
  "sha1",
  "thiserror",
- "utf-8",
 ]
 
 [[package]]
@@ -499,12 +579,6 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "utf-8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "uuid"
@@ -528,6 +602,15 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -588,6 +671,12 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "zerocopy"

--- a/hello-websocket-rust/client/main.rs
+++ b/hello-websocket-rust/client/main.rs
@@ -36,7 +36,7 @@ async fn try_connect(url: &str) -> Result<(), Box<dyn std::error::Error + Send +
 
     // Send HELLO
     let hello = Message::Hello { client_language: CLIENT_LANG.to_string() };
-    ws_sender.send(WsMessage::Binary(hello.encode())).await?;
+    ws_sender.send(WsMessage::Binary(hello.encode().into())).await?;
 
     let sender = std::sync::Arc::new(tokio::sync::Mutex::new(ws_sender));
     let sender_clone = sender.clone();
@@ -49,7 +49,7 @@ async fn try_connect(url: &str) -> Result<(), Box<dyn std::error::Error + Send +
             let num: i64 = rand::random();
             let rn = Message::RandomNumber { id, number: num };
             let mut s = sender_clone.lock().await;
-            if s.send(WsMessage::Binary(rn.encode())).await.is_err() { break; }
+            if s.send(WsMessage::Binary(rn.encode().into())).await.is_err() { break; }
             log("ws-client", &format!("RANDOM_NUMBER id={} number={}", id, num));
             id += 1;
         }
@@ -81,7 +81,7 @@ async fn try_connect(url: &str) -> Result<(), Box<dyn std::error::Error + Send +
                 log("ws-client", &format!("PING ts={}", timestamp_ms));
                 let pong = Message::Pong { timestamp_ms };
                 let mut s = sender.lock().await;
-                let _ = s.send(WsMessage::Binary(pong.encode())).await;
+                let _ = s.send(WsMessage::Binary(pong.encode().into())).await;
                 log("ws-client", &format!("PONG ts={}", timestamp_ms));
             }
             Message::TimeNotification { timestamp_ms, iso8601 } => {
@@ -95,7 +95,7 @@ async fn try_connect(url: &str) -> Result<(), Box<dyn std::error::Error + Send +
                     time_zone: "UTC".to_string(),
                 };
                 let mut s = sender.lock().await;
-                let _ = s.send(WsMessage::Binary(resp.encode())).await;
+                let _ = s.send(WsMessage::Binary(resp.encode().into())).await;
                 log("ws-client", "KISS_RESPONSE sent");
             }
             Message::EchoResponse { status, results } => {
@@ -120,7 +120,7 @@ async fn try_connect(url: &str) -> Result<(), Box<dyn std::error::Error + Send +
     // Send DISCONNECT
     let disconnect = Message::Disconnect { reason: "client shutdown".to_string() };
     let mut s = sender.lock().await;
-    let _ = s.send(WsMessage::Binary(disconnect.encode())).await;
+    let _ = s.send(WsMessage::Binary(disconnect.encode().into())).await;
 
     Ok(())
 }

--- a/hello-websocket-rust/server/main.rs
+++ b/hello-websocket-rust/server/main.rs
@@ -44,7 +44,7 @@ async fn handle_connection(stream: tokio::net::TcpStream, _addr: SocketAddr) {
     // Sender task
     let sender_task = tokio::spawn(async move {
         while let Some(data) = rx.recv().await {
-            if ws_sender.send(WsMessage::Binary(data)).await.is_err() {
+            if ws_sender.send(WsMessage::Binary(data.into())).await.is_err() {
                 break;
             }
         }

--- a/hello-websocket-ts/scripts/run-client.sh
+++ b/hello-websocket-ts/scripts/run-client.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
 cd "$(dirname "$0")/.."
-exec npx ts-node --esm client/ws_client.ts
+exec node --loader ts-node/esm client/ws_client.ts

--- a/hello-websocket-ts/scripts/run-server.sh
+++ b/hello-websocket-ts/scripts/run-server.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
 cd "$(dirname "$0")/.."
-exec npx ts-node --esm server/ws_server.ts
+exec node --loader ts-node/esm server/ws_server.ts


### PR DESCRIPTION
Four small, independent fixes — kept in separate commits for easy cherry-pick / revert.

- **dart**: send a full 64-bit random number (Dart VM is 64-bit native ints; the old 2^53-1 ceiling was a JS safe-int artifact that loses precision before the byte trip)
- **python**: read the PONG timestamp from the local `pong` oneof variable instead of `msg.pong`
- **rust**: `tungstenite::Message::Binary` wants `Bytes` not `Vec<u8>`, so coerce prost's `encode()` with `.into()` at every send site (client + server); `Cargo.lock` refresh picks up tungstenite's new wasm-bindgen graph
- **ts**: invoke `ts-node` via `node --loader ts-node/esm` in the run-*.sh scripts so they don't silently fall through to `tsx` when `ts-node` isn't on PATH; matches `npm run {client,server}`

Verified `cargo check --all-targets` on the Rust commit (tungstenite 0.29.0 + tokio-tungstenite 0.29.0 + prost).

Skipped: `hello-websocket-java/dependency-reduced-pom.xml` (maven-shade-plugin build artifact; belongs in .gitignore, not in this PR).